### PR TITLE
Added node prepare script for windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ Use [Angular 5](https://angular.io/) to easily create native mobile apps with Ax
 
 ## Getting started
 
-You can checkout how Titanium Angular works by taking a look at the bundled example application. To get started, first prepare all bundled packages by installing their dependencies with `node ./prepare.js`. After that, go to the example project in `ti-angular-example`. You can now build and run the app with `appc run -p [android|ios]`.
+You can checkout how Titanium Angular works by taking a look at the bundled example application.
+To get started, run the following commands in the root of this project:
+
+- `npm install`
+- `node ./prepare.js`
+
+After that, go to the example project in `ti-angular-example`. You can now build and run the app with `appc run -p [android|ios]`.
 
 ## Development Guide
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use [Angular 5](https://angular.io/) to easily create native mobile apps with Ax
 
 ## Getting started
 
-You can checkout how Titanium Angular works by taking a look at the bundled example application. To get started, first prepare all bundled packages by installing their dependencies with `sh prepare.sh`. After that, go to the example project in `ti-angular-example`. You can now build and run the app with `appc run -p [android|ios]`.
+You can checkout how Titanium Angular works by taking a look at the bundled example application. To get started, first prepare all bundled packages by installing their dependencies with `node ./prepare.js`. After that, go to the example project in `ti-angular-example`. You can now build and run the app with `appc run -p [android|ios]`.
 
 ## Development Guide
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "rimraf": "^2.6.2"
+  }
+}

--- a/prepare.js
+++ b/prepare.js
@@ -1,0 +1,29 @@
+var cp = require('child_process');
+var rimraf = require('rimraf');
+var path = require('path');
+var root = __dirname;
+
+// List of directories that require node_modules to be installed.
+var list = [
+    'packages/titanium-angular',
+    'packages/webpack-dev-titanium',
+    'ti-angular-example/app'
+];
+
+var currentDir;
+
+console.log('Installing npm modules...');
+
+// Loop the directories and clear + install npm modules.
+for(var i = 0; i < list.length; i++) {
+    currentDir = path.join(root, list[i]);
+    process.chdir(currentDir);
+
+    console.log(' ');
+    console.log(list[i] + ' (' + (i + 1) + ' of ' + list.length + ')');
+    console.log('Removing "' + path.join(list[i], 'node_modules') + '"...');
+    rimraf.sync('node_modules', []);
+    console.log('Installing "' + path.join(list[i], 'node_modules') + '"...');
+    cp.execSync('npm install');
+}
+console.log('Done!');


### PR DESCRIPTION
#6 

I originally created a `package.json` in the root directory that was named `titanium-angular`, but then I noticed this is actually a collection of packages, since that name is already used in `packages/titanium-angular/package.json`.

So instead of a `npm run prepare` command, you have to run `node ./prepare.js` from the root of the project to install the node modules. The root `package.json` only contains a "dependencies" key.

**Note that this currently still fails on Windows**, because of the error `npm ERR! titanium-angular@0.1.0 clean: 'rm -rf ./dist'` (which are linux commands in another file  `packages/titanium-angular/package.json`).