### PR TITLE
[FRAME-10] Move providers to router module

### DIFF
--- a/packages/titanium-angular/src/common/HistoryStack.ts
+++ b/packages/titanium-angular/src/common/HistoryStack.ts
@@ -9,14 +9,26 @@ export interface LocationState {
     queryString: string
 }
 
+/**
+ * A stack based history of location states, mimicking the HTML5 History API.
+ */
 @Injectable()
 export class HistoryStack {
 
+    /**
+     * List of location states.
+     */
     private states: Array<LocationState> = [];
 
+    /**
+     * Used to announce state changes to subscribers.
+     */
     private statesSubject = new Subject<LocationChangeEvent>();
 
-    get state() {
+    /**
+     * Gets the most recent state from the top of the stack.
+     */
+    get state(): LocationState {
         if (this.states.length === 0) {
             return null;
         }
@@ -24,15 +36,30 @@ export class HistoryStack {
         return this.states[this.states.length - 1];
     }
 
-    get length() {
+    /**
+     * Gets the number of entries currently stored in the history.
+     */
+    get length(): number {
         return this.states.length;
     }
 
+    /**
+     * Pops the most recent history entry from the top of the stack and issues an
+     * 'onpopstate' event.
+     */
     back() {
         const poppedState = this.popState();
         this.statesSubject.next({ type: 'onpopstate' });
     }
 
+    /**
+     * Pushes a new hitory entry to the top of the stack.
+     * 
+     * @param state Custom state data associate with the history entry
+     * @param title A short title for the new state
+     * @param url The new history entry's URL
+     * @param queryParams Any query parameters of the history entry
+     */
     pushState(state: any, title: string, url: string, queryParams: string): void {
         this.states.push({
             state: state,
@@ -42,6 +69,14 @@ export class HistoryStack {
         });
     }
 
+    /**
+     * Replaces the topmost history entry with a new one.
+     * 
+     * @param state Custom state data associate with the history entry
+     * @param title A short title for the new state
+     * @param url The new history entry's URL
+     * @param queryParams Any query parameters of the history entry
+     */
     replaceState(state: any, title: string, url: string, queryParams: string): void {
         if (this.states.length > 0) {
             console.log(`replacing existing state`);
@@ -56,7 +91,7 @@ export class HistoryStack {
     }
 
     /**
-     * Removes the top state from the stack.
+     * Removes the topmost history entry from the stack.
      * 
      * Note that this does not notify any onpopstate listeners. This is for
      * internal modification of the history stack. For backwards navigation use
@@ -66,16 +101,29 @@ export class HistoryStack {
         return this.states.pop();
     }
 
+    /**
+     * Registers a new handler function for the 'popstate' event
+     * 
+     * @param fn Handler function
+     */
     onPopState(fn: LocationChangeListener): void {
         this.statesSubject.subscribe((locationChangeEvent) => {
             fn(locationChangeEvent);
         });
     }
 
+    /**
+     * Returns a copy of the current history stack.
+     */
     snapshotStack(): Array<LocationState> {
         return [...this.states];
     }
 
+    /**
+     * Replaces all history entries with the given entries.
+     * 
+     * @param states List of history entries
+     */
     restoreStack(states: Array<LocationState>): void {
         this.states = states;
     }

--- a/packages/titanium-angular/src/platform/providers.ts
+++ b/packages/titanium-angular/src/platform/providers.ts
@@ -13,7 +13,6 @@ import {
 
 import { NavigationTransitionHandler, TransitionRegistry } from '../animation';
 import { TitaniumSanitizer } from '../core/TitaniumSanitizer';
-import { HistoryStack, TitaniumPlatformLocation } from '../common';
 import { FileSystemResourceLoader, TitaniumElementSchemaRegistry } from '../compiler';
 import { Logger } from '../log';
 import { NavigationManager } from '../router/NavigationManager';
@@ -31,9 +30,6 @@ export const COMMON_PROVIDERS = [
     { provide: NavigationTransitionHandler, useClass: NavigationTransitionHandler, deps: [TransitionRegistry] },
     { provide: TitaniumElementRegistry, useClass: TitaniumElementRegistry, deps: [Logger]},
     { provide: PLATFORM_INITIALIZER, useValue: initDomAdapter, multi: true },
-    { provide: HistoryStack, useClass: HistoryStack, deps: [] },
-    { provide: NavigationManager, useClass: NavigationManager, deps: [Injector, Logger] },
-    { provide: PlatformLocation, useClass: TitaniumPlatformLocation, deps: [HistoryStack, NavigationManager] },
     { provide: Sanitizer, useClass: TitaniumSanitizer, deps: [] }
 ];
 

--- a/packages/titanium-angular/src/router/NavigationManager.ts
+++ b/packages/titanium-angular/src/router/NavigationManager.ts
@@ -1,4 +1,3 @@
-import { Location, LocationStrategy } from "@angular/common";
 import { ComponentRef, Injectable, Injector, Type } from "@angular/core";
 import { Subscription } from "rxjs";
 
@@ -76,7 +75,7 @@ export class NavigationManager {
     /**
      * Constructs the navigation manager.
      * 
-     * @param injector Global Angular root injector
+     * @param injector Router module injector
      * @param logger Default logger instance
      */
     constructor(injector: Injector, logger: Logger) {
@@ -192,6 +191,11 @@ export class NavigationManager {
             this.activeNavigator.closeRootWindow();
             this.popNavigator();
         }
+    }
+
+    resetBackNavigationFlags() {
+        this.nativeBackNavigation = false;
+        this.locationBackNavigation = false;
     }
 
     /**

--- a/packages/titanium-angular/src/router/TitaniumRouterModule.ts
+++ b/packages/titanium-angular/src/router/TitaniumRouterModule.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { ExtraOptions, RouteReuseStrategy, RouterModule, Routes } from '@angular/router';
 
-import { EmulatedPathLocationStrategy } from '../common';
+import { HistoryStack, TitaniumPlatformLocation, EmulatedPathLocationStrategy } from '../common';
 import { Logger } from '../log';
 import { TitaniumCommonModule } from '../TitaniumCommonModule';
 import { TitaniumRouterLinkDirective, TitaniumRouterOutletDirective } from './directives';
@@ -24,6 +24,10 @@ const ROUTER_DIRECTIVES = [
 ];
 
 const ROUTER_PROVIDERS: Provider[] = [
+    NavigationManager,
+    HistoryStack,
+    TitaniumPlatformLocation,
+    { provide: PlatformLocation, useExisting: TitaniumPlatformLocation },
     { provide: EmulatedPathLocationStrategy, useClass: EmulatedPathLocationStrategy, deps: [PlatformLocation] },
     { provide: LocationStrategy, useExisting: EmulatedPathLocationStrategy },
     { provide: NavigationAwareRouteReuseStrategy, useClass: NavigationAwareRouteReuseStrategy, deps: [NavigationManager, Logger] },

--- a/packages/titanium-angular/src/router/directives/TitaniumRouterOutletDirective.ts
+++ b/packages/titanium-angular/src/router/directives/TitaniumRouterOutletDirective.ts
@@ -161,17 +161,32 @@ export class TitaniumRouterOutletDirective implements OnInit, OnDestroy {
         this.deactivateEvents.emit(componentInstance);
     }
 
+    /**
+     * Reattaches a route.
+     * 
+     * The order in which the back navigation flags are checked is important here.
+     * When a back navigation was triggeered by a native event, such as the back
+     * button in the iOS navigation bar or the hardware back button on Android,
+     * both flags are set to true. This is because the navigators internally
+     * use the Location.back() method to sync router states. This also sets the
+     * isLocationBackNavigation to true. But only when it was set without a
+     * natively triggered back navigation, the NavigationManager.back() method
+     * has to be called.
+     * 
+     * @param ref 
+     * @param activedRoute 
+     */
     attach(ref: ComponentRef<any>, activedRoute: ActivatedRoute) {
         this.logger.trace('TitaniumRouterOutlet.attach');
 
         this.activated = ref;
         this._activatedRoute = activedRoute;
 
-        if (this.navigationManager.isLocationBackNavigation) {
+        if (this.navigationManager.isNativeBackNavigation) {
+            this.navigationManager.resetBackNavigationFlags();
+        } else if (this.navigationManager.isLocationBackNavigation) {
             this.navigationManager.back();
-            this.navigationManager.locationBackNavigation = false;
-        } else if (this.navigationManager.isNativeBackNavigation) {
-            this.navigationManager.nativeBackNavigation = false;
+            this.navigationManager.resetBackNavigationFlags();
         }
     }
 


### PR DESCRIPTION
Follow up fix for https://jira.appcelerator.org/browse/FRAME-10, moving providers for routing related helpers to the routing module and checking back navigation flags in the correct order.